### PR TITLE
watch for changes and recompile script.js to script-compiled.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,18 @@
   "version": "1.0.2",
   "description": "setup for using es6 for bl.ocks.org",
   "main": "gist/script.js",
+  "watch": {
+    "build": {
+      "patterns": [
+        "script.js"
+      ]
+    }
+  },
   "scripts": {
     "build": "buble gist/script.js > gist/script-compiled.js",
-    "serve": "cd gist; live-server --port=8888"
+    "serve": "npm-run-all --parallel watch-js live-server",
+    "watch-js": "npm-watch build",
+    "live-server" : "live-server gist --port=8888"
   },
   "repository": {
     "type": "git",
@@ -21,6 +30,8 @@
     "buble": "^0.15.1",
     "gistup": "^0.1.3",
     "live-server": "^1.1.0",
-    "npm": "^4.0.5"
+    "npm": "^4.0.5",
+    "npm-run-all": "4.0.2",
+    "npm-watch": "0.1.9"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Run: `npm update` in the console to install npm modules
 
 ------------------
 
-## transpile es6 code using [buble](https://gitlab.com/Rich-Harris/buble): 
+## transpile es6 code using [buble](https://gitlab.com/Rich-Harris/buble):
 
 `npm run build` will compile using the below script:
 
@@ -36,15 +36,15 @@ view at: http://localhost:8888/
 
 ## end
 
-once all working as desired, navigate to the gist folder: `cd gist` 
+once all working as desired, navigate to the gist folder: `cd gist`
 
 1. replace `thumbnail.png` (or delete it if not using thumbnail on blocks)
 2. replace `preview.png` (or delete it if not using social media preview)
 3. update `README.md`
+4. Optionally, if you want script-compiled.js to be hidden once you push the gist to the block, rename it to `.script-compiled.js` and update the corresponding script tag in `index.html`
 
 finally create the gist: `gistup -m 'd3 | your title'`
 
 **NOTE** for further options using gistup: https://github.com/mbostock/gistup
 
 ------------------
-


### PR DESCRIPTION
Hello, thanks very much for setting up this template. 
I noticed that updates in script.js were not automatically triggering the build task, necessitating me to manually `npm run build` every time I updated script.js, so I added a watch command so that the `serve` command now recompiles script.js whenever necessary.